### PR TITLE
Added migration that fixes the incorrectly named `imageId` columns to…

### DIFF
--- a/backend/database/migrations/1585215875366-FixImageIdColumnNames.ts
+++ b/backend/database/migrations/1585215875366-FixImageIdColumnNames.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class FixImageIdColumnNames1585215875366 implements MigrationInterface {
+	public async up(queryRunner: QueryRunner): Promise<any> {
+		await queryRunner.renameColumn('games', 'imageId', 'image_id');
+		await queryRunner.renameColumn('ability_examples', 'imageId', 'image_id');
+	}
+
+	public async down(): Promise<any> {
+		throw new Error('Unsupported');
+	}
+}


### PR DESCRIPTION
… `image_id`